### PR TITLE
[SA-14299] Allow worker to monitor all queues

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -47,7 +47,10 @@ module Delayed
           scope = scope.scoped(:conditions => ['priority <= ?', Worker.max_priority]) if Worker.max_priority
 
           if Worker.queue
-            scope = scope.scoped(:conditions => ['queue = ?', Worker.queue])
+            # "__all__" for an unconstrained query, e.g. all queues
+            if Worker.queue.strip.downcase != '__all__'
+              scope = scope.scoped(:conditions => ['queue = ?', Worker.queue])
+            end
           else
             scope = scope.scoped(:conditions => ['queue is NULL'])
           end


### PR DESCRIPTION
This lets us use a single worker to handle all jobs in our "deployer" dev environments.